### PR TITLE
Fix detailedError plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1117,3 +1117,7 @@ Add createDate to each inserted to collection document
 ###### updateDate
 
 Add updateDate to each updated or replaces document
+
+###### detailedError
+
+Add field `operation` with query info to error object

--- a/lib/plugins/detailedError.js
+++ b/lib/plugins/detailedError.js
@@ -4,7 +4,7 @@ module.exports = function(collection) {
 	collection.on('error', function(params, callback) {
 		params.error.operation = {};
 		for (var key in params) {
-			if (key !== 'err') {
+			if (key !== 'error') {
 				params.error.operation[key] = params[key];
 			}
 		}


### PR DESCRIPTION
Fix error field name in `detailedError` plugin to prevent circular structure creation.

Also add a little bit of doc for plugin in readme.