### PR TITLE
Add extra info to detailedErrоr plugin

### DIFF
--- a/lib/mongodbext.js
+++ b/lib/mongodbext.js
@@ -62,6 +62,7 @@ Collection.prototype._getTriggerErrorHook = function(params) {
 		for (var key in params) {
 			errorTriggerParams[key] = params[key];
 		}
+		errorTriggerParams.namespace = self.namespace;
 		errorTriggerParams.error = err;
 
 		self.trigger('error', [errorTriggerParams], function(err) {
@@ -168,7 +169,8 @@ Collection.prototype.insertOne = function(doc, options, callback) {
 
 	var triggerErrorHook = this._getTriggerErrorHook({
 		doc: doc,
-		options: options
+		options: options,
+		method: 'insertOne'
 	});
 
 	var isReturnDocsOnly = this._getExtendOption(options, 'returnDocsOnly');
@@ -230,7 +232,8 @@ Collection.prototype.insertMany = function(docs, options, callback) {
 
 	var triggerErrorHook = this._getTriggerErrorHook({
 		docs: docs,
-		options: options
+		options: options,
+		method: 'insertMany'
 	});
 
 	var isReturnDocsOnly = this._getExtendOption(options, 'returnDocsOnly');
@@ -303,7 +306,8 @@ var getUpdateWithHooks = function(updateType) {
 		var triggerErrorHook = this._getTriggerErrorHook({
 			condition: filter,
 			modifier: update,
-			options: options
+			options: options,
+			method: methodName
 		});
 
 		var isReturnResultOnly = this._getExtendOption(options, 'returnResultOnly');
@@ -382,6 +386,7 @@ Collection.prototype.findOneAndUpdate = function(filter, update, options, callba
 		condition: filter,
 		modifier: update,
 		options: options,
+		method: 'findOneAndUpdate'
 	});
 
 	var isReturnDocsOnly = this._getExtendOption(options, 'returnDocsOnly');
@@ -453,7 +458,8 @@ var getDeleteWithHooks = function(updateType) {
 
 		var triggerErrorHook = this._getTriggerErrorHook({
 			condition: filter,
-			options: options
+			options: options,
+			method: methodName
 		});
 
 		var isReturnResultOnly = this._getExtendOption(options, 'returnResultOnly');
@@ -517,7 +523,8 @@ Collection.prototype.findOneAndDelete = function(filter, options, callback) {
 
 	var triggerErrorHook = this._getTriggerErrorHook({
 		condition: filter,
-		options: options
+		options: options,
+		method: 'findOneAndDelete'
 	});
 
 	var isReturnDocsOnly = this._getExtendOption(options, 'returnDocsOnly');
@@ -590,7 +597,8 @@ Collection.prototype.replaceOne = function(filter, update, options, callback) {
 	var triggerErrorHook = this._getTriggerErrorHook({
 		condition: filter,
 		replacement: update,
-		options: options
+		options: options,
+		method: 'replaceOne'
 	});
 
 	var isReturnResultOnly = this._getExtendOption(options, 'returnResultOnly');
@@ -661,7 +669,8 @@ Collection.prototype.findOneAndReplace = function(filter, replacement, options, 
 	var triggerErrorHook = this._getTriggerErrorHook({
 		condition: filter,
 		replacement: replacement,
-		options: options
+		options: options,
+		method: 'findOneAndReplace'
 	});
 
 	var isReturnDocsOnly = this._getExtendOption(options, 'returnDocsOnly');
@@ -731,7 +740,8 @@ Collection.prototype.findOneAndUpsert = function(filter, update, options, callba
 	var triggerErrorHook = this._getTriggerErrorHook({
 		condition: filter,
 		modifier: update,
-		options: options
+		options: options,
+		method: 'findOneAndUpsert'
 	});
 
 	var isReturnDocsOnly = this._getExtendOption(options, 'returnDocsOnly');

--- a/lib/mongodbext.js
+++ b/lib/mongodbext.js
@@ -694,7 +694,7 @@ Collection.prototype.findOneAndReplace = function(filter, replacement, options, 
 				matchedCount = lastErrorObject ? lastErrorObject.n : 0,
 				nativeResult = {
 					matchedCount: matchedCount,
-					modfifiedCount: matchedCount,
+					modifiedCount: matchedCount,
 					upsertedId: null
 				},
 				afterHookParams = {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "trigger"
   ],
   "scripts": {
-    "test": "mocha --reporter spec --bail --recursive"
+    "test": "mocha --reporter spec --bail --timeout 10000 --recursive"
   },
   "main": "./lib/mongodbext",
   "dependencies": {

--- a/test/deleteMany.js
+++ b/test/deleteMany.js
@@ -184,6 +184,8 @@ describe('Test deleteMany', function() {
 					error: function(params, callback) {
 						expect(params.condition).eql(condition);
 						expect(params.options).eql({});
+						expect(params.method).eql('deleteMany');
+						expect(params.namespace).eql(helpers.getNamespace());
 						expect(params.error).ok();
 
 						params.error.hookCalled = true;

--- a/test/findOneAndUpsert.js
+++ b/test/findOneAndUpsert.js
@@ -300,6 +300,8 @@ describe('Test findOneAndUpsert', function() {
 						expect(params.condition).eql(condition);
 						expect(params.modifier).eql(modifier);
 						expect(params.options).eql({});
+						expect(params.method).eql('findOneAndUpsert');
+						expect(params.namespace).eql(helpers.getNamespace());
 						expect(params.error).ok();
 
 						params.error.hookCalled = true;

--- a/test/insertMany.js
+++ b/test/insertMany.js
@@ -161,6 +161,8 @@ describe('Test insert many', function() {
 					error: function(params, callback) {
 						expect(params.docs).eql(entities);
 						expect(params.options).eql({});
+						expect(params.method).eql('insertMany');
+						expect(params.namespace).eql(helpers.getNamespace());
 						expect(params.error).ok();
 
 						params.error.hookCalled = true;

--- a/test/insertOne.js
+++ b/test/insertOne.js
@@ -155,6 +155,8 @@ describe('Test insertOne', function() {
 					error: function(params, callback) {
 						expect(params.doc).eql(entity);
 						expect(params.options).eql({});
+						expect(params.method).eql('insertOne');
+						expect(params.namespace).eql(helpers.getNamespace());
 						expect(params.error).ok();
 
 						params.error.hookCalled = true;

--- a/test/updateMany.js
+++ b/test/updateMany.js
@@ -226,6 +226,8 @@ describe('Test updateMany', function() {
 						expect(params.condition).eql(condition);
 						expect(params.modifier).eql(modifier);
 						expect(params.options).eql({});
+						expect(params.method).eql('updateMany');
+						expect(params.namespace).eql(helpers.getNamespace());
 						expect(params.error).ok();
 
 						params.error.hookCalled = true;


### PR DESCRIPTION
Add `namespace` and `method` to error info and update tests.

Also fix typo in `findOneAndReplace` method in lib.