### PR TITLE
Update error message in detailed error plugin

### DIFF
--- a/lib/plugins/detailedError.js
+++ b/lib/plugins/detailedError.js
@@ -3,11 +3,32 @@
 module.exports = function(collection) {
 	collection.on('error', function(params, callback) {
 		params.error.operation = {};
+		var operation = {
+			namespace: '',
+			method: '',
+			query: {},
+			options: {}
+		};
+
 		for (var key in params) {
 			if (key !== 'error') {
-				params.error.operation[key] = params[key];
+				if (key in operation) {
+					operation[key] = params[key];
+				} else {
+					operation.query[key] = params[key];
+				}
 			}
 		}
+
+		params.error.operation = operation;
+		params.error.message = [
+			'Error occured during execution operation:',
+			'error: ' + params.error.message,
+			'namespace: ' + operation.namespace,
+			'method: ' + operation.method,
+			'query: ' + JSON.stringify(operation.query, null, 2),
+			'options: ' + JSON.stringify(operation.options, null, 2)
+		].join('\n');
 
 		callback();
 	});

--- a/lib/plugins/index.js
+++ b/lib/plugins/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
 	createDate: require('./createDate'),
 	updateDate: require('./updateDate'),

--- a/test/plugins/detailedError.js
+++ b/test/plugins/detailedError.js
@@ -43,7 +43,11 @@ describe('Test detailedError plugin', function() {
 				function(err) {
 					expect(err).ok();
 					expect(err.operation).ok();
-					expect(err.operation.doc).eql(entity);
+					expect(err.operation.namespace).eql(helpers.getNamespace());
+					expect(err.operation.method).eql('insertOne');
+					expect(err.operation.query).eql({
+						doc: entity
+					});
 					expect(err.operation.options).eql({});
 
 					helpers.cleanDb(done);
@@ -71,7 +75,9 @@ describe('Test detailedError plugin', function() {
 				function(err) {
 					expect(err).ok();
 					expect(err.operation).ok();
-					expect(err.operation.docs).eql(entities);
+					expect(err.operation.namespace).eql(helpers.getNamespace());
+					expect(err.operation.method).eql('insertMany');
+					expect(err.operation.query.docs).eql(entities);
 					expect(err.operation.options).ok();
 
 					helpers.cleanDb(done);
@@ -82,7 +88,7 @@ describe('Test detailedError plugin', function() {
 
 	var itUpdateWithError = function(params) {
 		it(
-			params.operation + ' with error in before hook, ' +
+			params.method + ' with error in before hook, ' +
 				'should return error with operation info',
 			function(done) {
 				var condition = {
@@ -96,13 +102,15 @@ describe('Test detailedError plugin', function() {
 					function() {
 						collection.on(params.hookName, helpers.beforeHookWithError);
 
-						collection[params.operation](condition, modifier, this.slot());
+						collection[params.method](condition, modifier, this.slot());
 					},
 					function(err) {
 						expect(err).ok();
 						expect(err.operation).ok();
-						expect(err.operation.condition).eql(condition);
-						expect(err.operation.modifier).eql(modifier);
+						expect(err.operation.namespace).eql(helpers.getNamespace());
+						expect(err.operation.method).eql(params.method);
+						expect(err.operation.query.condition).eql(condition);
+						expect(err.operation.query.modifier).eql(modifier);
 						expect(err.operation.options).eql({});
 
 						done();
@@ -113,25 +121,25 @@ describe('Test detailedError plugin', function() {
 	};
 
 	itUpdateWithError({
-		operation: 'updateOne',
+		method: 'updateOne',
 		hookName: 'beforeUpdateOne'
 	});
 	itUpdateWithError({
-		operation: 'findOneAndUpdate',
+		method: 'findOneAndUpdate',
 		hookName: 'beforeUpdateOne'
 	});
 	itUpdateWithError({
-		operation: 'findOneAndUpsert',
+		method: 'findOneAndUpsert',
 		hookName: 'beforeUpsertOne'
 	});
 	itUpdateWithError({
-		operation: 'updateMany',
+		method: 'updateMany',
 		hookName: 'beforeUpdateMany'
 	});
 
 	var itDeleteWithError = function(params) {
 		it(
-			params.operation + ' with error in before hook, ' +
+			params.method + ' with error in before hook, ' +
 				'should return error with operation info',
 			function(done) {
 				var condition = {
@@ -144,12 +152,14 @@ describe('Test detailedError plugin', function() {
 					function() {
 						collection.on(params.hookName, helpers.beforeHookWithError);
 
-						collection[params.operation](condition, this.slot());
+						collection[params.method](condition, this.slot());
 					},
 					function(err) {
 						expect(err).ok();
 						expect(err.operation).ok();
-						expect(err.operation.condition).eql(condition);
+						expect(err.operation.namespace).eql(helpers.getNamespace());
+						expect(err.operation.method).eql(params.method);
+						expect(err.operation.query.condition).eql(condition);
 						expect(err.operation.options).eql({});
 
 						done();
@@ -160,15 +170,15 @@ describe('Test detailedError plugin', function() {
 	};
 
 	itDeleteWithError({
-		operation: 'deleteOne',
+		method: 'deleteOne',
 		hookName: 'beforeDeleteOne'
 	});
 	itDeleteWithError({
-		operation: 'findOneAndDelete',
+		method: 'findOneAndDelete',
 		hookName: 'beforeDeleteOne'
 	});
 	itDeleteWithError({
-		operation: 'deleteMany',
+		method: 'deleteMany',
 		hookName: 'beforeDeleteMany'
 	});
 


### PR DESCRIPTION
Create detailed message about error in `detailedError` plugin. For example:
```
Error occured during execution operation:
error: E11000 duplicate key error collection: mongodbext_test.test index: _id_ dup key: { : 76 }
namespace: mongodbext_test.test
method: insertMany
query: {
  "docs": [
    {
      "a": 1,
      "_id": 76
    },
    {
      "a": 1,
      "_id": 77
    }
  ]
}
options: {
  "checkKeys": true
}
```

Update `detailedError` plugin tests.