### PR TITLE
use databaseName from database for v3 driver

### DIFF
--- a/lib/collection/index.js
+++ b/lib/collection/index.js
@@ -12,7 +12,7 @@ var Collection = function(db, collectionName, options) {
 		this,
 		db,
 		db.s.topology,
-		db.s.databaseName,
+		db.databaseName || db.s.databaseName,
 		collectionName,
 		null,
 		options


### PR DESCRIPTION
In mongodb driver v3 some things changed, for example getting db name got much easier