### PR TITLE
forwarding error after ensureSequenceCollection in sequence plugin

### DIFF
--- a/lib/plugins/sequence.js
+++ b/lib/plugins/sequence.js
@@ -51,7 +51,7 @@ module.exports = function(collection, options) {
 		if (!subjectObjs.length) return callback();
 
 		ensureSequenceCollection(function(err) {
-			if (err) return callback();
+			if (err) return callback(err);
 
 			getCurrentValueAndIncrease(subjectObjs.length, function(err, value) {
 				if (err) return callback(err);


### PR DESCRIPTION
If an error occurs in the **ensureSequenceCollection** function then the **sequence** plugin will not set sequence id