### PR TITLE
Add beforeUpsertOne hook handling in createDate plugin

### DIFF
--- a/lib/collection/findOneAndUpsert.js
+++ b/lib/collection/findOneAndUpsert.js
@@ -48,9 +48,6 @@ module.exports = function(Collection) {
 				return triggerErrorHook(err, callback);
 			}
 
-			// modifier can be replaced in before hook
-			update = beforeHookParams.modifier;
-
 			var sourceCallback = function(err, upsertResult) {
 				if (err) {
 					return triggerErrorHook(err, callback);

--- a/lib/collection/findOneAndUpsert.js
+++ b/lib/collection/findOneAndUpsert.js
@@ -34,11 +34,6 @@ module.exports = function(Collection) {
 
 		var isReturnDocsOnly = this._getExtendOption(options, 'returnDocsOnly');
 
-		// check what should we do, update or replace
-		var sourceMethodName = (
-			utils.isModifier(update) ? 'findOneAndUpdate' : 'findOneAndReplace'
-		);
-
 		var meta = {};
 
 		var beforeHookParams = {
@@ -52,6 +47,8 @@ module.exports = function(Collection) {
 			if (err) {
 				return triggerErrorHook(err, callback);
 			}
+
+			update = beforeHookParams.modifier;
 
 			var sourceCallback = function(err, upsertResult) {
 				if (err) {
@@ -83,6 +80,11 @@ module.exports = function(Collection) {
 				sourceOptions[key] = options[key];
 			}
 			sourceOptions.upsert = true;
+
+			// check what should we do, update or replace
+			var sourceMethodName = (
+				utils.isModifier(update) ? 'findOneAndUpdate' : 'findOneAndReplace'
+			);
 
 			// try to call function twice because of bug:
 			// https://jira.mongodb.org/browse/SERVER-14322

--- a/lib/collection/findOneAndUpsert.js
+++ b/lib/collection/findOneAndUpsert.js
@@ -48,6 +48,7 @@ module.exports = function(Collection) {
 				return triggerErrorHook(err, callback);
 			}
 
+			// modifier can be replaced in before hook
 			update = beforeHookParams.modifier;
 
 			var sourceCallback = function(err, upsertResult) {

--- a/lib/collection/findOneAndUpsert.js
+++ b/lib/collection/findOneAndUpsert.js
@@ -34,6 +34,11 @@ module.exports = function(Collection) {
 
 		var isReturnDocsOnly = this._getExtendOption(options, 'returnDocsOnly');
 
+		// check what should we do, update or replace
+		var sourceMethodName = (
+			utils.isModifier(update) ? 'findOneAndUpdate' : 'findOneAndReplace'
+		);
+
 		var meta = {};
 
 		var beforeHookParams = {
@@ -78,11 +83,6 @@ module.exports = function(Collection) {
 				sourceOptions[key] = options[key];
 			}
 			sourceOptions.upsert = true;
-
-			// check what should we do, update or replace
-			var sourceMethodName = (
-				utils.isModifier(update) ? 'findOneAndUpdate' : 'findOneAndReplace'
-			);
 
 			// try to call function twice because of bug:
 			// https://jira.mongodb.org/browse/SERVER-14322

--- a/lib/plugins/createDate.js
+++ b/lib/plugins/createDate.js
@@ -46,11 +46,10 @@ module.exports = function(collection, options) {
 				setOnInsertModifier
 			);
 		} else {
-			var setters = modifier;
-			params.modifier = {
-				$set: setters,
-				$setOnInsert: setOnInsertModifier
-			};
+			Object.assign(
+				params.modifier,
+				setOnInsertModifier
+			);
 		}
 
 		callback();

--- a/lib/plugins/createDate.js
+++ b/lib/plugins/createDate.js
@@ -37,9 +37,7 @@ module.exports = function(collection, options) {
 
 		var isModifierEmpty = !Object.keys(modifier).length;
 		if (isModifierEmpty) {
-			params.modifier = {
-				$setOnInsert: setOnInsertModifier
-			};
+			params.modifier = setOnInsertModifier;
 		} else if (utils.isModifier(modifier)) {
 			modifier.$setOnInsert = Object.assign({},
 				modifier.$setOnInsert,

--- a/lib/plugins/createDate.js
+++ b/lib/plugins/createDate.js
@@ -41,7 +41,7 @@ module.exports = function(collection, options) {
 				$setOnInsert: setOnInsertModifier
 			};
 		} else if (utils.isModifier(modifier)) {
-			modifier.$setOnInsert = Object.asssign(
+			modifier.$setOnInsert = Object.assign({},
 				modifier.$setOnInsert,
 				setOnInsertModifier
 			);

--- a/lib/plugins/createDate.js
+++ b/lib/plugins/createDate.js
@@ -21,6 +21,42 @@ module.exports = function(collection, options) {
 		callback();
 	};
 
+	var beforeUpsert = function(params, callback) {
+		var modifier = params.modifier;
+
+		var isCreateDateProvided =
+			(modifier.$setOnInsert && modifier.$setOnInsert.createDate !== undefined) ||
+			(modifier.$set && modifier.$set.createDate !== undefined) ||
+			modifier.createDate !== undefined;
+
+		if (isCreateDateProvided) {
+			return callback();
+		}
+
+		var setOnInsertModifier = {createDate: dateFormatter(new Date())};
+
+		var isModifierEmpty = !Object.keys(modifier).length;
+		if (isModifierEmpty) {
+			params.modifier = {
+				$setOnInsert: setOnInsertModifier
+			};
+		} else if (utils.isModifier(modifier)) {
+			modifier.$setOnInsert = Object.asssign(
+				modifier.$setOnInsert,
+				setOnInsertModifier
+			);
+		} else {
+			var setters = modifier;
+			params.modifier = {
+				$set: setters,
+				$setOnInsert: setOnInsertModifier
+			};
+		}
+
+		callback();
+	};
+
 	collection.on('beforeInsertOne', beforeInsert);
 	collection.on('beforeInsertMany', beforeInsert);
+	collection.on('beforeUpsertOne', beforeUpsert);
 };

--- a/lib/plugins/createDate.js
+++ b/lib/plugins/createDate.js
@@ -35,10 +35,7 @@ module.exports = function(collection, options) {
 
 		var setOnInsertModifier = {createDate: dateFormatter(new Date())};
 
-		var isModifierEmpty = !Object.keys(modifier).length;
-		if (isModifierEmpty) {
-			params.modifier = setOnInsertModifier;
-		} else if (utils.isModifier(modifier)) {
+		if (utils.isModifier(modifier)) {
 			modifier.$setOnInsert = Object.assign({},
 				modifier.$setOnInsert,
 				setOnInsertModifier

--- a/test/plugins/createDate.js
+++ b/test/plugins/createDate.js
@@ -81,6 +81,56 @@ var describeCheckPlugin = function(params) {
 			);
 		});
 
+		it('make findOneAndUpsert, should be ok', function(done) {
+			var entity = helpers.getEntity();
+
+			Steppy(
+				function() {
+					collection.findOneAndUpsert({_id: entity._id}, entity, this.slot());
+				},
+				function() {
+					collection.findOne(this.slot());
+				},
+				function(err, result) {
+					expect(result).ok();
+					expect(result.createDate).ok();
+					expect(result.createDate).to.be.a(params.createDateType);
+					if (params.createDateRegExp) {
+						expect(result.createDate).match(params.createDateRegExp);
+					}
+					expect(result._id).eql(entity._id);
+
+					helpers.cleanDb(this.slot());
+				},
+				done
+			);
+		});
+
+		it('make findOneAndUpsert, should skip', function(done) {
+			var entity = params.withCreateDate(helpers.getEntity());
+
+			Steppy(
+				function() {
+					collection.findOneAndUpsert({_id: entity._id}, entity, this.slot());
+				},
+				function() {
+					collection.findOne(this.slot());
+				},
+				function(err, result) {
+					expect(result).ok();
+					if (params.createDate instanceof Date) {
+						expect(Number(result.createDate)).to.be(Number(params.createDate));
+					} else {
+						expect(result.createDate).to.be(params.createDate);
+					}
+					expect(result._id).eql(entity._id);
+
+					helpers.cleanDb(this.slot());
+				},
+				done
+			);
+		});
+
 		it('make insertMany, should be ok', function(done) {
 			var entities = [helpers.getEntity(), helpers.getEntity()];
 			Steppy(

--- a/test/plugins/createDate.js
+++ b/test/plugins/createDate.js
@@ -106,12 +106,16 @@ var describeCheckPlugin = function(params) {
 			);
 		});
 
-		it('make findOneAndUpsert with update operator, should be ok', function(done) {
+		it('make findOneAndUpsert with modifier, should be ok', function(done) {
 			var entity = helpers.getEntity();
 
 			Steppy(
 				function() {
-					collection.findOneAndUpsert({_id: entity._id}, {$set: entity}, this.slot());
+					collection.findOneAndUpsert(
+						{_id: entity._id},
+						{$set: entity},
+						this.slot()
+					);
 				},
 				function() {
 					collection.findOne(this.slot());
@@ -131,12 +135,16 @@ var describeCheckPlugin = function(params) {
 			);
 		});
 
-		it('make findOneAndUpsert with update operator, should skip', function(done) {
+		it('make findOneAndUpsert with modifier, should skip', function(done) {
 			var entity = params.withCreateDate(helpers.getEntity());
 
 			Steppy(
 				function() {
-					collection.findOneAndUpsert({_id: entity._id}, {$set: entity}, this.slot());
+					collection.findOneAndUpsert(
+						{_id: entity._id},
+						{$set: entity},
+						this.slot()
+					);
 				},
 				function() {
 					collection.findOne(this.slot());

--- a/test/plugins/createDate.js
+++ b/test/plugins/createDate.js
@@ -106,6 +106,56 @@ var describeCheckPlugin = function(params) {
 			);
 		});
 
+		it('make findOneAndUpsert with update operator, should be ok', function(done) {
+			var entity = helpers.getEntity();
+
+			Steppy(
+				function() {
+					collection.findOneAndUpsert({_id: entity._id}, {$set: entity}, this.slot());
+				},
+				function() {
+					collection.findOne(this.slot());
+				},
+				function(err, result) {
+					expect(result).ok();
+					expect(result.createDate).ok();
+					expect(result.createDate).to.be.a(params.createDateType);
+					if (params.createDateRegExp) {
+						expect(result.createDate).match(params.createDateRegExp);
+					}
+					expect(result._id).eql(entity._id);
+
+					helpers.cleanDb(this.slot());
+				},
+				done
+			);
+		});
+
+		it('make findOneAndUpsert with update operator, should skip', function(done) {
+			var entity = params.withCreateDate(helpers.getEntity());
+
+			Steppy(
+				function() {
+					collection.findOneAndUpsert({_id: entity._id}, {$set: entity}, this.slot());
+				},
+				function() {
+					collection.findOne(this.slot());
+				},
+				function(err, result) {
+					expect(result).ok();
+					if (params.createDate instanceof Date) {
+						expect(Number(result.createDate)).to.be(Number(params.createDate));
+					} else {
+						expect(result.createDate).to.be(params.createDate);
+					}
+					expect(result._id).eql(entity._id);
+
+					helpers.cleanDb(this.slot());
+				},
+				done
+			);
+		});
+
 		it('make findOneAndUpsert, should skip', function(done) {
 			var entity = params.withCreateDate(helpers.getEntity());
 


### PR DESCRIPTION
Register `beforeUpsertOne` hook in `createDate` plugin. In that hook add `createDate` field to `$setOnInsert` modifier if it not present in condition and modifier yet. 
So, `createDate` would be correctly setted when using `findOneAnaUpsert` method with `createDate` plugin.
Fix #18 